### PR TITLE
Fix remove_document method bugs in memory services

### DIFF
--- a/app/memory/multi_model_storage.py
+++ b/app/memory/multi_model_storage.py
@@ -301,9 +301,12 @@ class MultiModelEmbeddingStorage:
     
     def remove_document(self, document_id: str) -> bool:
         """Remove a specific document by ID"""
+        if not document_id or not document_id.strip():
+            return False
+
         original_count = len(self.documents)
         self.documents = [doc for doc in self.documents if doc["document_id"] != document_id]
-        
+
         if len(self.documents) < original_count:
             self._save_data(self.documents, self.documents_file)
             return True

--- a/app/services/hybrid_memory_service.py
+++ b/app/services/hybrid_memory_service.py
@@ -410,5 +410,5 @@ class HybridMemoryService(MemoryService):
         if self.multi_model_enabled and self.multi_model_storage:
             return self.multi_model_storage.remove_document(document_id)
         else:
-            self.logger.warning("Document removal only supported in multi-model mode")
-            return False
+            # Use base MemoryService implementation for non-multi-model mode
+            return super().remove_document(document_id)

--- a/app/services/memory_service.py
+++ b/app/services/memory_service.py
@@ -811,8 +811,23 @@ class MemoryService:
     
     def remove_document(self, document_id: str) -> bool:
         """Remove a specific document from knowledge base"""
-        if document_id in self.knowledge_manager.documents:
-            del self.knowledge_manager.documents[document_id]
+        if not document_id or not document_id.strip():
+            return False
+
+        original_count = len(self.knowledge_manager.documents)
+        self.knowledge_manager.documents = [
+            doc for doc in self.knowledge_manager.documents
+            if doc.get("id") != document_id
+        ]
+
+        if len(self.knowledge_manager.documents) < original_count:
+            # Also remove associated embeddings
+            self.knowledge_manager.chunk_embeddings = [
+                emb for emb in self.knowledge_manager.chunk_embeddings
+                if emb.get("doc_id") != document_id
+            ]
+            # Save changes
+            self.knowledge_manager._save_data()
             return True
         return False
     


### PR DESCRIPTION

Fix: Remove Document Method Bugs in Memory Services

Problem
=======

The remove_document method had critical bugs preventing document deletion:

1. memory_service.py: Treated documents as dictionary instead of list, causing KeyError
2. hybrid_memory_service.py: Always returned False in non-multi-model mode instead of using base implementation
3. multi_model_storage.py: Missing input validation for empty/null document_id

Solution
========

1. Fixed list filtering logic in memory_service.py:
   - Changed from dict operations to list filtering
   - Removes associated embeddings for data consistency
   - Saves changes to persist deletion

2. Added fallback in hybrid_memory_service.py:
   - Delegates to base MemoryService.remove_document() when multi-model disabled

3. Added input validation in multi_model_storage.py:
   - Validates document_id is not empty/null before processing

Files Changed
=============

- app/services/memory_service.py: Fixed list filtering, added embedding cleanup and validation
- app/services/hybrid_memory_service.py: Added fallback to base implementation
- app/memory/multi_model_storage.py: Added input validation

Impact
======

- Breaking Changes: None
- Backward Compatibility: Fully compatible
- Functionality: Document deletion now works correctly in all modes
